### PR TITLE
Fix profile icons in finished game card

### DIFF
--- a/src/cogs/CardGenerator.py
+++ b/src/cogs/CardGenerator.py
@@ -467,7 +467,7 @@ class CardGenerator(commands.Cog):
             latest_patch = sorted(patch_folders)[0] if patch_folders else "15.1.1"
             
             # Try to load the profile icon
-            profile_icon_path = os.path.join(self.assets_path, "gamedata", self.bot.current_game_patch, "img", "profileicon", f"{profile_icon_id}.png")
+            profile_icon_path = os.path.join(self.assets_path, "gamedata", latest_patch, "img", "profileicon", f"{profile_icon_id}.png")
             
             try:
                 if os.path.exists(profile_icon_path):


### PR DESCRIPTION
## Summary
- ensure finished game cards load profile icons using available patch folders instead of `current_game_patch`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68618ac93b448324878ad5937c0f25b3