### PR TITLE
Fix cherry game card deletion

### DIFF
--- a/src/cogs/Loops.py
+++ b/src/cogs/Loops.py
@@ -368,15 +368,16 @@ class Loops(commands.Cog):
                                 # Generate player cards
                                 player_cards = await self.bot.get_cog("CardGenerator").generate_finished_game_card(match_id)
                                 
-                                # Edit the original message with the match summary and first card
-                                if player_cards:
-                                    await message.edit(embed=summary_embed, file=player_cards[0])
-                                    # Send additional cards if there are more than one
-                                    for card_file in player_cards[1:]:
-                                        await channel.send(file=card_file)
-                                else:
-                                    # If no cards were generated, just edit with the summary
-                                    await message.edit(embed=summary_embed)
+                                # Send the match summary first
+                                await channel.send(embed=summary_embed)
+                                
+                                # Send all player cards
+                                for card_file in player_cards:
+                                    await channel.send(file=card_file)
+                                
+                                # Delete the original "CHERRY Match Queued" message after a delay
+                                await asyncio.sleep(5)
+                                await message.delete()
                                 
                                 # Remove from pending queue
                                 await self.bot.get_cog("DatabaseOperations").remove_pending_match(match_id)


### PR DESCRIPTION
Align cherry gamemode queue processing with regular game flow by deleting the original queued message and sending new messages for summary and cards.

Previously, when a CHERRY match was processed from the queue, the original "CHERRY Match Queued" message was edited to display the match summary and player cards. This was inconsistent with the behavior for regular games, where the live game card is deleted and new messages are sent for the summary and player cards. This change ensures that the queued message is deleted, and the match results are presented in new messages, providing a consistent user experience.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-fa553733-6e87-47a0-ab27-db4b904a142d) · [Cursor](https://cursor.com/background-agent?bcId=bc-fa553733-6e87-47a0-ab27-db4b904a142d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)